### PR TITLE
Removing dbt compile step from DAG parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The only files required for the Airflow DAGs to run are `dbt_project.yml`, `prof
 your own dbt workflow, feel free to drop in your own project files.
 
 
-**Notes** 
+## Notes
 - If you make changes to the dbt project, you will need to run `dbt compile` in order to update the `manifest.json` file. 
 This may be done manually during development, as part of a CI/CD pipeline, or as a separate step in a production pipeline 
 run *before* the Airflow DAG is triggered.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ your own dbt workflow, feel free to drop in your own project files.
 
 **Notes** 
 - If you make changes to the dbt project, you will need to run `dbt compile` in order to update the `manifest.json` file. 
-This may be done as part of a CI/CD pipeline, or as a separate step in a production pipeline run *before* the
-Airflow DAG is triggered.
+This may be done manually during development, as part of a CI/CD pipeline, or as a separate step in a production pipeline 
+run *before* the Airflow DAG is triggered.
 - The sample dbt project contains the `profiles.yml`, which is configured to use Astronomer's 
 containerized postgres database **solely for the purpose of this demo**. In a production environment, you should use a 
 production-ready database and use environment variables or some other form of secret management for the database 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ The only files required for the Airflow DAGs to run are `dbt_project.yml`, `prof
 `target/manifest.json`, but we included the models for completeness. If you would like to try these DAGs with 
 your own dbt workflow, feel free to drop in your own project files.
 
+
 **Notes** 
+- If you make changes to the dbt project, you will need to run `dbt compile` in order to update the `manifest.json` file. 
+This may be done as part of a CI/CD pipeline, or as a separate step in a production pipeline run *before* the
+Airflow DAG is triggered.
 - The sample dbt project contains the `profiles.yml`, which is configured to use Astronomer's 
 containerized postgres database **solely for the purpose of this demo**. In a production environment, you should use a 
 production-ready database and use environment variables or some other form of secret management for the database 

--- a/include/dbt_dag_parser.py
+++ b/include/dbt_dag_parser.py
@@ -41,20 +41,8 @@ class DbtDagParser:
         self.dbt_run_group = TaskGroup(dbt_run_group_name)
         self.dbt_test_group = TaskGroup(dbt_test_group_name)
 
-        # Compile the manifest, then parse it and populate the two task groups
-        self.compile_dbt()
+        # Parse the manifest and populate the two task groups
         self.make_dbt_task_groups()
-
-    def compile_dbt(self):
-        """
-        Calls dbt compile in a subprocess to ensure the manifest is up-to-date.
-
-        Returns: None
-
-        """
-        compile_command = f'dbt compile --project-dir {self.dbt_project_dir}'.split(' ')
-        logging.info('Compiling dbt project: %s', compile_command)
-        subprocess.run(compile_command)
 
     def load_dbt_manifest(self):
         """


### PR DESCRIPTION
Addresses #3: I'm removing the compile step from the DbtDagParser init to prevent it from running each time the scheduler parses out the dag file. Also added a note about this in the README, hope this is clear. The demo repo will still run out of the box since the manifest.json is included, so this only affects users who want to either use the DbtDagParser in their own project or change out/modify the dbt project in the demo.