### PR TITLE
Fix dbt_seed downstream dependencies on dbt_advanced.py

### DIFF
--- a/dags/dbt_advanced.py
+++ b/dags/dbt_advanced.py
@@ -78,7 +78,10 @@ with DAG(
             node_test = node.replace("model", "test")
             dbt_tasks[node] >> dbt_tasks[node_test]
             # Set all model -> model dependencies
-            for upstream_node in data["nodes"][node]["depends_on"]["nodes"]:
+            upstream_nodes = data["nodes"][node]["depends_on"]["nodes"]
+            if not upstream_nodes:
+                dbt_seed >> dbt_tasks[node]
+            for upstream_node in upstream_nodes:
                 upstream_node_type = upstream_node.split(".")[0]
                 if upstream_node_type == "model":
-                    dbt_seed >> dbt_tasks[upstream_node] >> dbt_tasks[node]
+                    dbt_tasks[upstream_node] >> dbt_tasks[node]


### PR DESCRIPTION
I recently used the python module `dbt_advanced.py` as example to create a DAG that generate dbt tasks dynamically from manifest files. This repo was very useful.

I just noticed that the code is adding unnecessary connections from `dbt_seed` to other tasks that already are connected with their upstream tasks. See the example below.

![image](https://user-images.githubusercontent.com/35263725/174104595-1f3c4cbb-22bb-42dd-8ba7-f8c90c4e6071.png)

This MR changes the code to generate a cleaner DAG without those unnecessary connections. The `dbt_seed` should be connected only with tasks that have no upstream ones. See the example below after applying my changes.

![image](https://user-images.githubusercontent.com/35263725/174103150-6a23503d-6e3d-4fe7-8962-a1c59875feab.png)

I don't know if you're accepting contributions to this repository, but follow the PR.
